### PR TITLE
Fix: Ensure logout button and user status are visible after login

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,12 @@
 <body>
     <header>
         <h1>Gym Progress Tracker</h1>
+        <div id="user-status" style="display: none;"> <!-- Moved out of auth-container -->
+            <span id="user-email"></span>
+            <button id="logout-btn" class="button-secondary">Logout</button>
+        </div>
         <div id="auth-container">
-            <div id="user-status" style="display: none;">
-                <span id="user-email"></span>
-                <button id="logout-btn" class="button-secondary">Logout</button>
-            </div>
+            {_} <!-- Placeholder for login/signup forms which remain inside auth-container -->
             <form id="signup-form" style="display: none;">
                 <h3>Sign Up</h3>
                 <input type="email" id="signup-email" placeholder="Email" required>


### PR DESCRIPTION
- Restructured index.html to move the 'user-status' div (containing user email and logout button) out of the 'auth-container' div.
- This allows 'user-status' to be displayed when a user is logged in, while 'auth-container' (with login/signup forms) is hidden.
- The existing JavaScript logic in updateUIForAuthState should now correctly manage the visibility of these elements.