### PR TITLE
Feat: Implement date-grouped set display and per-day numbering

### DIFF
--- a/style.css
+++ b/style.css
@@ -534,6 +534,17 @@ ul.styled-list { /* Remove default list styling if ul is used */
     /* height: auto !important; -- Removed, let Chart.js handle it */
 }
 
+.date-separator {
+    font-weight: bold;
+    color: var(--primary-color);
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+    text-align: center;
+    border-top: 1px solid var(--input-border);
+    border-bottom: 1px solid var(--input-border);
+    padding: 5px 0;
+}
+
 /* 1RM Calculator Styling */
 #one-rep-max-calculator h4 {
     color: var(--primary-color);


### PR DESCRIPTION
- Modified Set Tracker view (`renderSetsForExercise`) to group sets by date, add date separators, and number sets per day (most recent day first).
- Modified Detailed Exercise View (`renderDetailedExerciseView`) for 'All History' and 'Last Day' modes to use the same date-grouped display with per-day set numbering.
- Ensured 1RM calculator in Detailed View continues to use all sets for the exercise name.
- Added CSS for date separators.
- This addresses user request for clearer set organization.