### PR TITLE
Revert: Roll back date-grouping changes to restore login

### DIFF
--- a/style.css
+++ b/style.css
@@ -534,17 +534,6 @@ ul.styled-list { /* Remove default list styling if ul is used */
     /* height: auto !important; -- Removed, let Chart.js handle it */
 }
 
-.date-separator {
-    font-weight: bold;
-    color: var(--primary-color);
-    margin-top: 1em;
-    margin-bottom: 0.5em;
-    text-align: center;
-    border-top: 1px solid var(--input-border);
-    border-bottom: 1px solid var(--input-border);
-    padding: 5px 0;
-}
-
 /* 1RM Calculator Styling */
 #one-rep-max-calculator h4 {
     color: var(--primary-color);


### PR DESCRIPTION
- Reverted script.js to its state prior to the 'Feat: Implement date-grouped set display and per-day numbering' commit.
- Removed .date-separator CSS from style.css.

This is to restore login functionality which was broken by the recent date-grouping feature implementation.