### PR TITLE
Feat: Date grouping for Set Tracker view

### DIFF
--- a/style.css
+++ b/style.css
@@ -534,6 +534,17 @@ ul.styled-list { /* Remove default list styling if ul is used */
     /* height: auto !important; -- Removed, let Chart.js handle it */
 }
 
+.date-separator {
+    font-weight: bold;
+    color: var(--primary-color);
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+    text-align: center;
+    border-top: 1px solid var(--input-border);
+    border-bottom: 1px solid var(--input-border);
+    padding: 5px 0;
+}
+
 /* 1RM Calculator Styling */
 #one-rep-max-calculator h4 {
     color: var(--primary-color);


### PR DESCRIPTION
- Implemented date grouping for set display in the Set Tracker view (renderSetsForExercise).
- Sets are grouped by day, with date separators.
- Set numbering restarts daily.
- Most recent dates are displayed first; sets are chronological within each day.
- Re-added .date-separator CSS.
- Uses robust getYYYYMMDD utility for date keying.