### PR TITLE
Feat: Add day separators to 'All History' exercise view

### DIFF
--- a/style.css
+++ b/style.css
@@ -679,3 +679,11 @@ ul.styled-list { /* Remove default list styling if ul is used */
 .hidden {
     display: none !important;
 }
+
+/* Separator for sets on different days in detailed history view */
+hr.day-separator {
+    margin-top: 15px;
+    margin-bottom: 10px;
+    border: 0;
+    border-top: 1px solid #555; /* A medium gray, adjust as needed for theme */
+}


### PR DESCRIPTION
- In the detailed exercise view, when 'All History' is selected, sets performed on different calendar days are now visually separated by a horizontal line.
- Added JavaScript logic to detect date changes between sets and insert an <hr> element.
- Added CSS styling for the day separator line.