### PR TITLE
Fix: Correct clearViewState call in auth.js on logout

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -178,7 +178,7 @@ export function initializeAuth() {
         const user = session ? session.user : null;
 
         if (event === 'SIGNED_OUT') {
-            placeholderViewManager.clearViewState(); // From viewManager
+            viewManager.clearViewState(); // Use actual imported viewManager
             state.setAppInitializedOnce(false);
         }
 


### PR DESCRIPTION
- Replaced placeholderViewManager.clearViewState() with viewManager.clearViewState() in the onAuthStateChange handler for the SIGNED_OUT event.
- This resolves an error caused by the removal of placeholderViewManager.